### PR TITLE
Handle English correctly

### DIFF
--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -177,7 +177,7 @@ class Deepl implements PermissionProvider
             isset($parsed['language']) &&
             $parsed['language'] == 'en'
         ) {
-            return $parsed['language'] . '-' . $parsed['region'];
+            return $parsed['language'] . '-' . $parsed['region'] == 'GB' ? 'GB' : 'US' ;
         }
         
         if ($parsed && isset($parsed['language'])) {

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -171,6 +171,15 @@ class Deepl implements PermissionProvider
     public static function language_from_locale(?string $locale = null): ?string
     {
         $parsed = locale_parse($locale);
+
+        if (
+            $parsed &&
+            isset($parsed['language']) &&
+            $parsed['language'] == 'en'
+        ) {
+            return $parsed['language'] . '-' . $parsed['region'];
+        }
+        
         if ($parsed && isset($parsed['language'])) {
             return $parsed['language'];
         }


### PR DESCRIPTION
Relevant error message: `targetLang="en" is deprecated, please use "en-GB" or "en-US" instead.`

When translating to English the target region needs to be specified (`US` or `GB`), so I added a check to do just that.

Docs: https://support.deepl.com/hc/en-us/articles/360019925219-Languages-included-in-DeepL-Pro