### PR TITLE
Source for english should be EN. Target GB/US.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 yarn.lock
 
+/.idea

--- a/src/ApiController.php
+++ b/src/ApiController.php
@@ -36,7 +36,7 @@ class ApiController extends Controller
             $request->postVar('toLocale')
         );
         $fromLanguage = Deepl::language_from_locale(
-            $request->postVar('fromLocale')
+            $request->postVar('fromLocale'), true
         );
         $text = $request->postVar('text');
 
@@ -93,7 +93,7 @@ class ApiController extends Controller
         $acc = new ArrayList();
 
         $defaultLocale = Locale::getDefault();
-        $sourceLang = Deepl::language_from_locale($defaultLocale->Locale);
+        $sourceLang = Deepl::language_from_locale($defaultLocale->Locale, true);
 
         Glossary::get()
             ->filter([
@@ -148,14 +148,14 @@ class ApiController extends Controller
         ) {
             $locales = Locale::get()->sort('IsGlobalDefault DESC');
             $defaultLocale = $locales->find('IsGlobalDefault', true);
-            $sourceLang = Deepl::language_from_locale($defaultLocale->Locale);
+            $sourceLang = Deepl::language_from_locale($defaultLocale->Locale, true);
             $now = DBDatetime::now()->format(DBDatetime::ISO_DATETIME);
 
             foreach ($locales as $sourceLocale) {
                 foreach ($locales as $targetLocale) {
                     if ($sourceLocale->ID != $targetLocale->ID) {
                         $sourceLang = Deepl::language_from_locale(
-                            $sourceLocale->Locale
+                            $sourceLocale->Locale, true
                         );
                         $targetLang = Deepl::language_from_locale(
                             $targetLocale->Locale

--- a/src/DataObjectWiseTranslationExtension.php
+++ b/src/DataObjectWiseTranslationExtension.php
@@ -83,7 +83,7 @@ class DataObjectWiseTranslationExtension extends DataExtension
             $result = self::get_translator_class()::run(
                 $recordsCollection,
                 Deepl::language_from_locale($toLocale),
-                Deepl::language_from_locale($fromLocale)
+                Deepl::language_from_locale($fromLocale, true)
             );
 
             return $result;
@@ -153,7 +153,7 @@ class DataObjectWiseTranslationExtension extends DataExtension
             $result = ParallelTranslator::run(
                 $recordsCollection,
                 Deepl::language_from_locale($toLocale),
-                Deepl::language_from_locale($fromLocale)
+                Deepl::language_from_locale($fromLocale, true)
             );
 
             return $result;

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -168,7 +168,7 @@ class Deepl implements PermissionProvider
         }
     }
 
-    public static function language_from_locale(?string $locale = null): ?string
+    public static function language_from_locale(?string $locale = null, ?bool $source = false): ?string
     {
         $parsed = locale_parse($locale);
 
@@ -177,7 +177,11 @@ class Deepl implements PermissionProvider
             isset($parsed['language']) &&
             $parsed['language'] == 'en'
         ) {
-            return $parsed['language'] . '-' . $parsed['region'] == 'GB' ? 'GB' : 'US' ;
+            if ($source) {
+                return $parsed['language'];
+            }
+
+            return $parsed['language'] . '-' . $parsed['region'] == 'GB' ? 'GB' : 'US';
         }
         
         if ($parsed && isset($parsed['language'])) {

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -181,18 +181,7 @@ class Deepl implements PermissionProvider
                 return $parsed['language'];
             }
 
-            return $parsed['language'] . '-' . $parsed['region'] == 'GB' ? 'GB' : 'US';
-        }
-
-        // When target should be english, force en-GB or en-GB
-        // (see: https://developers.deepl.com/docs/resources/supported-languages#target-languages)
-        if (
-            !$source &&
-            $parsed &&
-            isset($parsed['language']) &&
-            ($parsed['language'] == 'US' || $parsed['language'] == 'GB')
-        ) {
-            return 'en-' . $parsed['language'];
+            return $parsed['language'] . '-' . ($parsed['region'] == 'GB' ? 'GB' : 'US');
         }
         
         if ($parsed && isset($parsed['language'])) {

--- a/src/Deepl.php
+++ b/src/Deepl.php
@@ -183,6 +183,17 @@ class Deepl implements PermissionProvider
 
             return $parsed['language'] . '-' . $parsed['region'] == 'GB' ? 'GB' : 'US';
         }
+
+        // When target should be english, force en-GB or en-GB
+        // (see: https://developers.deepl.com/docs/resources/supported-languages#target-languages)
+        if (
+            !$source &&
+            $parsed &&
+            isset($parsed['language']) &&
+            ($parsed['language'] == 'US' || $parsed['language'] == 'GB')
+        ) {
+            return 'en-' . $parsed['language'];
+        }
         
         if ($parsed && isset($parsed['language'])) {
             return $parsed['language'];

--- a/src/FieldWiseTranslationExtension.php
+++ b/src/FieldWiseTranslationExtension.php
@@ -74,7 +74,7 @@ class FieldWiseTranslationExtension extends DataExtension
                         $targetLanguage
                     ) {
                         $language = Deepl::language_from_locale(
-                            $r->Locale->Locale
+                            $r->Locale->Locale, true
                         );
 
                         $currentValues->push(

--- a/src/Glossary.php
+++ b/src/Glossary.php
@@ -76,12 +76,12 @@ class Glossary extends DataObject
             $locales->each(function ($locale) use ($defaultLocale) {
                 if ($locale->ID != $defaultLocale->ID) {
                     $source = Deepl::language_from_locale(
-                        $defaultLocale->Locale
+                        $defaultLocale->Locale, true
                     );
                     $target = Deepl::language_from_locale($locale->Locale);
                     if (
                         !self::by_source_and_target(
-                            Deepl::language_from_locale($defaultLocale->Locale),
+                            Deepl::language_from_locale($defaultLocale->Locale, true),
                             Deepl::language_from_locale($locale->Locale)
                         )
                     ) {


### PR DESCRIPTION
Added a $source attribute to `Deepl::language_from_locale` to distiguish source/target needs. For EN/US/GB you need to use "en" as source, us/gb for target.

See:
- https://github.com/DeepLcom/deepl-python/issues/33
- https://developers.deepl.com/docs/resources/supported-languages